### PR TITLE
Exclude PP810610.1 from 229e data [#12]

### DIFF
--- a/phylogenetic/config/229e/dropped_strains.txt
+++ b/phylogenetic/config/229e/dropped_strains.txt
@@ -1,3 +1,4 @@
 OK662398.1
 OK625404.1
 MZ712010.1
+PP810610.1 # extreme outlier in tree


### PR DESCRIPTION
## Description of proposed changes

When reviewing the updates, Katie noticed this sequence as a pretty extreme outlier in the `229e` dataset, and suggested pruning it. 

## Related issue(s)

#12 

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
