### PR TITLE
Remove `traits` rule and associated config [#32]

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -47,7 +47,6 @@ viruses:
     clock_filter_iqd: 4
   annotate_phylogeny:
     inference: "joint"
-    columns: "country"
 nl63:
   reference: "defaults/nl63/reference.fasta"
   genemap: "defaults/nl63/genemap.gff"
@@ -65,7 +64,6 @@ nl63:
     clock_filter_iqd: 4
   annotate_phylogeny:
     inference: "joint"
-    columns: "country"
 oc43:
   reference: "defaults/oc43/reference.fasta"
   genemap: "defaults/oc43/genemap.gff"
@@ -83,7 +81,6 @@ oc43:
     clock_filter_iqd: 4
   annotate_phylogeny:
     inference: "joint"
-    columns: "country"
 hku1:
   reference: "defaults/hku1/reference.fasta"
   genemap: "defaults/hku1/genemap.gff"
@@ -101,4 +98,3 @@ hku1:
     clock_filter_iqd: 4
   annotate_phylogeny:
     inference: "joint"
-    columns: "country"

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -51,27 +51,3 @@ rule translate:
             --output {output.node_data:q} \
           2>{log:q}
         """
-
-
-rule traits:
-    input:
-        tree="results/{virus}/tree.nwk",
-        metadata=lambda wildcards: config[wildcards.virus]["metadata"],
-    output:
-        node_data="results/{virus}/traits.json",
-    log:
-        "logs/{virus}/traits.txt",
-    benchmark:
-        "benchmarks/{virus}/traits.txt"
-    params:
-        columns=lambda wildcards: config[wildcards.virus]["annotate_phylogeny"]["columns"],
-    shell:
-        """
-        augur traits \
-            --tree {input.tree:q} \
-            --metadata {input.metadata:q} \
-            --output-node-data {output.node_data:q} \
-            --columns {params.columns:q} \
-            --confidence \
-          2>{log:q}
-        """


### PR DESCRIPTION
## Description of proposed changes

This removes the `traits` rule; the output wasn't being used. Also removes associated configuration values. 