### PR TITLE
Lock clock rates for 229E and OC43 [#36]

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -38,8 +38,8 @@ viruses:
     subsample_max_sequences: 4000
     min_length: 20000
   construct_phylogeny:
-    clock_rate: ""
-    clock_std_dev: ""
+    clock_rate: 0.000250
+    clock_std_dev: 0.00010
     coalescent: "opt"
     date_inference: "marginal"
     clock_filter_iqd: 4
@@ -68,8 +68,8 @@ oc43:
     subsample_max_sequences: 4000
     min_length: 20000
   construct_phylogeny:
-    clock_rate: ""
-    clock_std_dev: ""
+    clock_rate: 0.000250
+    clock_std_dev: 0.00010
     coalescent: "opt"
     date_inference: "marginal"
     clock_filter_iqd: 4

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -45,31 +45,19 @@ rule refine:
         date_inference=lambda wildcards: config[wildcards.virus]["construct_phylogeny"]["date_inference"],
         clock_filter_iqd=lambda wildcards: config[wildcards.virus]["construct_phylogeny"]["clock_filter_iqd"],
     shell:
-        # TODO move this conditional logic up into the params lambda (?)
         r"""
-        (
-          if [ "{wildcards.virus}" == "229e" ] || [ "{wildcards.virus}" == "oc43" ]; then
-              echo "Estimating clock rate for {wildcards.virus}"
-              clock_rate=""
-              clock_std_dev=""
-          else
-              echo "Setting clock rate at {params.clock_rate} with std dev {params.clock_std_dev} for {wildcards.virus}"
-              clock_rate="--clock-rate {params.clock_rate}"
-              clock_std_dev="--clock-std-dev {params.clock_std_dev}"
-          fi
-
-          augur refine \
-              --tree {input.tree:q} \
-              --alignment {input.alignment:q} \
-              --metadata {input.metadata:q} \
-              --output-tree {output.tree:q} \
-              --output-node-data {output.node_data:q} \
-              --timetree \
-              $clock_rate \
-              $clock_std_dev \
-              --coalescent {params.coalescent:q} \
-              --date-confidence \
-              --date-inference {params.date_inference:q} \
-              --clock-filter-iqd {params.clock_filter_iqd:q}
-        ) 2>{log:q}
+        augur refine \
+            --tree {input.tree:q} \
+            --alignment {input.alignment:q} \
+            --metadata {input.metadata:q} \
+            --output-tree {output.tree:q} \
+            --output-node-data {output.node_data:q} \
+            --timetree \
+            --clock-rate {params.clock_rate} \
+            --clock-std-dev {params.clock_std_dev} \
+            --coalescent {params.coalescent:q} \
+            --date-confidence \
+            --date-inference {params.date_inference:q} \
+            --clock-filter-iqd {params.clock_filter_iqd:q}
+          &> {log:q}
         """


### PR DESCRIPTION
## Description of proposed changes

Locks the clock rate and standard dev for these two species to the same rates as the other two species. 

Auspice JSONs [uploaded to staging](https://next.nextstrain.org/staging/seasonal-cov/) for preview. 

## Related issue(s)

Resolves #36 
<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
