### PR TITLE
Convert triple-quoted shell commands to "raw" style [#39]

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -28,7 +28,7 @@ else:
         output:
             metadata="results/{virus}/metadata.tsv",
         shell:
-            """
+            r"""
             mv {input.metadata:q} {output.metadata:q}
             """
 
@@ -42,7 +42,7 @@ rule clean:
             "results",
             ]
     shell:
-        """
+        r"""
         rm -rfv {params.targets}
         """
 

--- a/ingest/build-configs/nextstrain-automation/upload.smk
+++ b/ingest/build-configs/nextstrain-automation/upload.smk
@@ -29,7 +29,7 @@ rule upload_to_s3:
         s3_dst=config["s3_dst"],
         cloudfront_domain=config["cloudfront_domain"],
     shell:
-        """
+        r"""
         ./vendored/upload-to-s3 \
             {params.quiet} \
             {input.file_to_upload:q} \

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -21,7 +21,7 @@ rule fetch_general_geolocation_rules:
     params:
         geolocation_rules_url=config["curate"]["geolocation_rules_url"],
     shell:
-        """
+        r"""
         curl {params.geolocation_rules_url:q} \
           > {output.general_geolocation_rules:q} \
          2> {log:q}
@@ -39,7 +39,7 @@ rule concat_geolocation_rules:
     benchmark:
         "benchmarks/concat_geolocation_rules.txt"
     shell:
-        """
+        r"""
         cat {input.general_geolocation_rules:q} {input.local_geolocation_rules:q} \
           > {output.all_geolocation_rules:} \
          2> {log:q}
@@ -89,7 +89,7 @@ rule curate:
         sequence_field=config["curate"]["output_sequence_field"],
     shell:
         # note: params.field_map intentionally not quoted
-        """
+        r"""
         (
           cat {input.sequences_ndjson:q} \
             | augur curate rename \
@@ -133,7 +133,7 @@ rule subset_metadata:
     params:
         metadata_fields=",".join(config["curate"]["metadata_columns"]),
     shell:
-        """
+        r"""
         tsv-select -H -f {params.metadata_fields:q} \
             {input.metadata:q} \
           > {output.subset_metadata:q} \

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -17,7 +17,7 @@ rule fetch_ncbi_dataset_package:
     benchmark:
         "benchmarks/{virus}/fetch_ncbi_dataset_package.txt"
     shell:
-        """
+        r"""
         datasets download virus genome taxon {params.ncbi_taxon_id:q} \
             --no-progressbar \
             --filename {output.dataset_package:q} \
@@ -35,7 +35,7 @@ rule extract_ncbi_dataset_sequences:
     benchmark:
         "benchmarks/{virus}/extract_ncbi_dataset_sequences.txt"
     shell:
-        """
+        r"""
         unzip -jp {input.dataset_package:q} \
             ncbi_dataset/data/genomic.fna \
           > {output.ncbi_dataset_sequences:q} \
@@ -88,7 +88,7 @@ rule format_ncbi_dataset_report:
     benchmark:
         "benchmarks/{virus}/format_ncbi_dataset_report.txt"
     shell:
-        """
+        r"""
         dataformat tsv virus-genome \
             --package {input.dataset_package:q} \
             --fields {params.fields_to_include:q} \
@@ -112,7 +112,7 @@ rule format_ncbi_datasets_ndjson:
     benchmark:
         "benchmarks/{virus}/format_ncbi_datasets_ndjson.txt"
     shell:
-        """
+        r"""
         augur curate passthru \
             --metadata {input.ncbi_dataset_tsv:q} \
             --fasta {input.ncbi_dataset_sequences:q} \

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -23,7 +23,7 @@ rule clean:
             "results",
             ]
     shell:
-        """
+        r"""
         rm -rfv {params.targets}
         """
 

--- a/phylogenetic/build-configs/nextstrain-automation/deploy.smk
+++ b/phylogenetic/build-configs/nextstrain-automation/deploy.smk
@@ -14,6 +14,6 @@ rule deploy_all:
     params:
         deploy_url=config["deploy_url"],
     shell:
-        """
+        r"""
         nextstrain remote upload {params.deploy_url} {input}
         """

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -21,7 +21,7 @@ rule ancestral:
     params:
         inference=lambda wildcards: config[wildcards.virus]["annotate_phylogeny"]["inference"],
     shell:
-        """
+        r"""
         augur ancestral \
             --tree {input.tree:q} \
             --alignment {input.alignment:q} \
@@ -43,7 +43,7 @@ rule translate:
     benchmark:
         "benchmarks/{virus}/translate.txt"
     shell:
-        """
+        r"""
         augur translate \
             --tree {input.tree:q} \
             --ancestral-sequences {input.node_data:q} \

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -18,7 +18,7 @@ rule tree:
     benchmark:
         "benchmarks/{virus}/tree.txt"
     shell:
-        """
+        r"""
         augur tree \
             --alignment {input.alignment:q} \
             --output {output.tree:q} \
@@ -46,7 +46,7 @@ rule refine:
         clock_filter_iqd=lambda wildcards: config[wildcards.virus]["construct_phylogeny"]["clock_filter_iqd"],
     shell:
         # TODO move this conditional logic up into the params lambda (?)
-        """
+        r"""
         (
           if [ "{wildcards.virus}" == "229e" ] || [ "{wildcards.virus}" == "oc43" ]; then
               echo "Estimating clock rate for {wildcards.virus}"

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -24,7 +24,7 @@ rule export:
     benchmark:
         "benchmarks/{virus}/export.txt"
     shell:
-        """
+        r"""
         augur export v2 \
           --tree {input.tree:q} \
           --metadata {input.metadata:q} \

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -19,7 +19,7 @@ rule download:
         sequences_url="https://data.nextstrain.org/files/workflows/seasonal-cov/{virus}/sequences.fasta.zst",
         metadata_url="https://data.nextstrain.org/files/workflows/seasonal-cov/{virus}/metadata.tsv.zst",
     shell:
-        """
+        r"""
         curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}
         curl -fsSL --compressed {params.metadata_url:q} --output {output.metadata}
         """
@@ -33,7 +33,7 @@ rule decompress:
         sequences="data/{virus}/sequences.fasta",
         metadata="data/{virus}/metadata.tsv",
     shell:
-        """
+        r"""
         zstd -d -c {input.sequences} > {output.sequences}
         zstd -d -c {input.metadata} > {output.metadata}
         """
@@ -55,7 +55,7 @@ rule filter:
         subsample_max_sequences=lambda wildcards: config[wildcards.virus]["prepare_sequences"]["subsample_max_sequences"],
         min_length=lambda wildcards: config[wildcards.virus]["prepare_sequences"]["min_length"],
     shell:
-        """
+        r"""
         augur filter \
             --sequences {input.sequences:q} \
             --metadata {input.metadata:q} \
@@ -82,7 +82,7 @@ rule align:
     benchmark:
         "benchmarks/{virus}/align.txt"
     shell:
-        """
+        r"""
         (
           nextclade run \
               --input-ref {input.reference:q} \


### PR DESCRIPTION
## Description of proposed changes

Changes Snakemake `shell` commands to use "raw" triple-quoted strings. See nextstrain/docs.nextstrain.org#221 for context. 

## Related issue(s)

Closes #39 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
