### PR TITLE
Switch HKU1 build to mid-point rooting [#45]

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -42,6 +42,7 @@ tip_frequencies:
   reference: "defaults/229e/reference.fasta"
   genemap: "defaults/229e/genemap.gff"
   prepare_sequences:
+    exclude_where: "'host!=Homo sapiens'"
     group_by: "country"
     subsample_max_sequences: 4000
     min_length: 20000
@@ -58,6 +59,7 @@ nl63:
   reference: "defaults/nl63/reference.fasta"
   genemap: "defaults/nl63/genemap.gff"
   prepare_sequences:
+    exclude_where: "'host!=Homo sapiens'"
     group_by: "country"
     subsample_max_sequences: 4000
     min_length: 20000
@@ -74,6 +76,7 @@ oc43:
   reference: "defaults/oc43/reference.fasta"
   genemap: "defaults/oc43/genemap.gff"
   prepare_sequences:
+    exclude_where: "'host!=Homo sapiens'"
     group_by: "country"
     subsample_max_sequences: 4000
     min_length: 20000
@@ -90,6 +93,7 @@ hku1:
   reference: "defaults/hku1/reference.fasta"
   genemap: "defaults/hku1/genemap.gff"
   prepare_sequences:
+    exclude_where: "'host!=Homo sapiens' 'authors=Hikmat et al.'"
     group_by: "country"
     subsample_max_sequences: 4000
     min_length: 20000

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -29,6 +29,7 @@ tip_frequencies:
 #   min_length
 # construct_phylogeny = parameters related to tree building pipeline
 #   # augur refine param values
+#   root
 #   clock_rate
 #   clock_std_dev
 #   coalescent
@@ -45,6 +46,7 @@ tip_frequencies:
     subsample_max_sequences: 4000
     min_length: 20000
   construct_phylogeny:
+    root: "best"
     clock_rate: 0.000250
     clock_std_dev: 0.00010
     coalescent: "opt"
@@ -60,6 +62,7 @@ nl63:
     subsample_max_sequences: 4000
     min_length: 20000
   construct_phylogeny:
+    root: "best"
     clock_rate: 0.000120
     clock_std_dev: 0.00005
     coalescent: "opt"
@@ -75,6 +78,7 @@ oc43:
     subsample_max_sequences: 4000
     min_length: 20000
   construct_phylogeny:
+    root: "best"
     clock_rate: 0.000250
     clock_std_dev: 0.00010
     coalescent: "opt"
@@ -90,6 +94,7 @@ hku1:
     subsample_max_sequences: 4000
     min_length: 20000
   construct_phylogeny:
+    root: "mid_point"
     clock_rate: 0.000120
     clock_std_dev: 0.00005
     coalescent: "opt"

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -39,6 +39,7 @@ rule refine:
     benchmark:
         "benchmarks/{virus}/refine.txt"
     params:
+        root=lambda wildcards: config[wildcards.virus]["construct_phylogeny"]["root"],
         clock_rate=lambda wildcards: config[wildcards.virus]["construct_phylogeny"]["clock_rate"],
         clock_std_dev=lambda wildcards: config[wildcards.virus]["construct_phylogeny"]["clock_std_dev"],
         coalescent=lambda wildcards: config[wildcards.virus]["construct_phylogeny"]["coalescent"],
@@ -53,6 +54,7 @@ rule refine:
             --output-tree {output.tree:q} \
             --output-node-data {output.node_data:q} \
             --timetree \
+            --root {params.root:q} \
             --clock-rate {params.clock_rate} \
             --clock-std-dev {params.clock_std_dev} \
             --coalescent {params.coalescent:q} \

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -51,6 +51,7 @@ rule filter:
     benchmark:
         "benchmarks/{virus}/filter.txt"
     params:
+        exclude_where=lambda wildcards: config[wildcards.virus]["prepare_sequences"]["exclude_where"],
         group_by=lambda wildcards: config[wildcards.virus]["prepare_sequences"]["group_by"],
         subsample_max_sequences=lambda wildcards: config[wildcards.virus]["prepare_sequences"]["subsample_max_sequences"],
         min_length=lambda wildcards: config[wildcards.virus]["prepare_sequences"]["min_length"],
@@ -60,7 +61,7 @@ rule filter:
             --sequences {input.sequences:q} \
             --metadata {input.metadata:q} \
             --exclude {input.exclude:q} \
-            --exclude-where "host!=Homo sapiens" \
+            --exclude-where {params.exclude_where} \
             --output {output.sequences:q} \
             --group-by {params.group_by:q} \
             --subsample-max-sequences {params.subsample_max_sequences:q} \


### PR DESCRIPTION
## Description of proposed changes

* Switch HKU1 to `--root mid_point` 
* Fully parameterized `augur refine --root` flag to better support changing rooting of other viruses in the future
* Leaves other three strains with `--root best`, effectively as before
* Excludes HKU1 samples from Hikmat et al.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

Closes #45 
Closes #47 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
